### PR TITLE
Draft LC summing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ script:
   - npm test
 
 notifications:
-  slack: riceeclipse:gkom2AO57EGZmxU2wWPEtyR2
+  slack: riceeclipse:HVcYx7InaxdEFzQHaatd1UiH


### PR DESCRIPTION
For our senior design project, we plan on using _4 load cells_. Each of the load cells will be used together to measure a single item, so the team wants the load cell values to be summed (on both the frontend `resfet-dashboard` UI and in the datafiles that are produced during a test). Does the below code achieve this?

Also, I  understand that Eclipse recently purchased 4 load cells, but I think that the load cell names in `loadCells` (below) will persist (meaning that it is okay to hardcode them)? Also, since it was the only configuration JSON, I am assuming that `luna_hotfire` is appropriate to use here? 

Finally, our test is designed to last ~6.7 seconds. Where in `resfet-dashboard` or `resfet` would this time change go? 